### PR TITLE
Add configuration option to toggle between real-time and in-game time for vendor hours

### DIFF
--- a/client/classes/menu.lua
+++ b/client/classes/menu.lua
@@ -15,7 +15,13 @@ end
 
 function VendorMenu:openShop()
     if self.vendorConfig.hours.enabled then
-        local currentHour = lib.callback.await('snowy_vendors:getCurrentTime', false)
+        local currentHour
+        if self.vendorConfig.hours.realTime then
+            currentHour = lib.callback.await('snowy_vendors:getCurrentTime', false)
+        else
+            currentHour = GetClockHours()
+        end
+    
         if currentHour < self.vendorConfig.hours.open or currentHour >= self.vendorConfig.hours.close then
             lib.notify({
                 title = 'Vendor',

--- a/client/main.lua
+++ b/client/main.lua
@@ -52,6 +52,10 @@ CreateThread(function()
     RegisterVendors()
 end)
 
+lib.callback.register('snowy_vendors:getCurrentInGameTime', function()
+    return GetClockHours()
+end)
+
 AddEventHandler('onResourceStop', function(resourceName)
     if resourceName == GetCurrentResourceName() then
         RemoveVendors()

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -15,6 +15,7 @@ return {
             },
             hours = {
                 enabled = false,
+                realTime = true, -- If true, the time will use real-life time based on the user's location. If false, the time will use in-game time.
                 open = 2,  -- Opening hour (24-hour format)
                 close = 8, -- Closing hour (24-hour format)
             },

--- a/server/main.lua
+++ b/server/main.lua
@@ -34,7 +34,13 @@ lib.callback.register('snowy_vendors:buyItem', function(source, vendorId, itemNa
     if not vendor or not inventory then return false, "Invalid vendor" end
 
     if vendor.hours.enabled then
-        local currentHour = os.date("*t").hour
+        local currentHour
+        if vendor.hours.realTime then
+            currentHour = os.date("*t").hour
+        else
+            currentHour = lib.callback.await('snowy_vendors:getCurrentInGameTime', source)
+        end
+
         if currentHour < vendor.hours.open or currentHour >= vendor.hours.close then
             return false, "This vendor is currently closed"
         end
@@ -74,7 +80,13 @@ lib.callback.register('snowy_vendors:sellItem', function(source, vendorId, itemN
     if not vendor or not inventory then return false, "Invalid vendor" end
 
     if vendor.hours.enabled then
-        local currentHour = os.date("*t").hour
+        local currentHour
+        if vendor.hours.realTime then
+            currentHour = os.date("*t").hour
+        else
+            currentHour = lib.callback.await('snowy_vendors:getCurrentInGameTime', source)
+        end
+        
         if currentHour < vendor.hours.open or currentHour >= vendor.hours.close then
             return false, "This vendor is currently closed"
         end


### PR DESCRIPTION
I wasn't sure if the use of system time over game time was intentional, so I added a configuration option to allow switching between real-time and in-game hours.